### PR TITLE
HTML5 WebSocket compatibility for onmessage event.

### DIFF
--- a/lib/websockets/socket.js
+++ b/lib/websockets/socket.js
@@ -37,9 +37,9 @@ function WebSocket() {
       self.onopen();
   });
 
-  self.on('message', function() {
+  self.on('message', function(data) {
     if('function' === typeof self.onmessage)
-      self.onmessage();
+      self.onmessage({data:data});
   });
 
   self.on('_closing', function(reason) {


### PR DESCRIPTION
Onmessage expects a MessageEvent object, with a single attribute called "data". Also, the argument was not being used in any way, so there was no way to retrieve the data.

https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent
